### PR TITLE
feat: add-appname-mapping-lp

### DIFF
--- a/sigma/pipelines/logpoint/logpoint_mapping.py
+++ b/sigma/pipelines/logpoint/logpoint_mapping.py
@@ -2380,6 +2380,7 @@ logpoint_windows_common_taxonomy = {
     "FileName": "file",
     "FlagsHex": "flag",
     "HostApplication": "application",
+    "AppName": "application",
     "HostId": "host_id",
     "IpAddress": "source_address",
     "IpPort": "source_port",


### PR DESCRIPTION
update: logpoint_mapping - map 'appname' to 'application' for Event ID 1000 in Windows common taxonomy

affected file: sigma/pipelines/logpoint/logpoint_mapping.py

Added a mapping to the taxonomy section, that would directly solve an issue, where in the Case of an "event_id=1000" detection a used field Name "AppName" was converted to "app_name" instead of "application" - resulting in the field not catching anything.
This change would ensure that appname values are available in downstream queries and dashboards that rely on the "application" field.

Maintainers: please confirm there’s no other preferred target field name for this value.

Happy to adjust if there’s a broader taxonomy update underway!

sources:
https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/application/application_error/win_werfault_susp_lsass_credential_dump.yml https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/troubleshoot-application-service-crashing-behavior
